### PR TITLE
Update button state on main thread (potentially fix UI breakage)

### DIFF
--- a/wipbot/Plugin.cs
+++ b/wipbot/Plugin.cs
@@ -56,6 +56,7 @@ namespace wipbot
       "ogg",
       "egg",
       "wav",
+      "vivify",
       ""
     ];
     [UseConverter(typeof(ListConverter<string>))]

--- a/wipbot/Plugin.cs
+++ b/wipbot/Plugin.cs
@@ -256,7 +256,7 @@ namespace wipbot
             {
               wipQueue.RemoveAt(i);
               SendChatMessage(Config.Instance.MessageUndoRequest);
-              UnityMainThreadTaskScheduler.Factory.StartNew(() => { UpdateButtonState(); });
+              UnityMainThreadTaskScheduler.Factory.StartNew(UpdateButtonState);
               break;
             }
           }
@@ -310,7 +310,7 @@ namespace wipbot
             wipUrl = wipUrl.Replace(Config.Instance.UrlFindReplacePairs[i], Config.Instance.UrlFindReplacePairs[i + 1]);
           wipQueue.Add(new QueueItem() { UserName = userName, DownloadUrl = wipUrl });
           SendChatMessage(Config.Instance.MessageWipRequested);
-          UnityMainThreadTaskScheduler.Factory.StartNew(() => { UpdateButtonState(); });
+          UnityMainThreadTaskScheduler.Factory.StartNew(UpdateButtonState);
         }
       }
     }
@@ -417,7 +417,7 @@ namespace wipbot
           SendChatMessage(Config.Instance.ErrorMessageOther.Replace("%s", e.Message));
         webClient.CancelAsync();
       }
-      UnityMainThreadTaskScheduler.Factory.StartNew(() => { UpdateButtonState(); });
+      UnityMainThreadTaskScheduler.Factory.StartNew(UpdateButtonState);
     }
 
     public static void OnLevelsRefreshed()

--- a/wipbot/Plugin.cs
+++ b/wipbot/Plugin.cs
@@ -91,12 +91,12 @@ namespace wipbot
     
     public virtual int ConfigVersion { get; set; } = 0;
     public virtual int QueueSize { get; set; } = 9;
-    public virtual int ButtonPositionX { get; set; } = 151;
-    public virtual int ButtonPositionY { get; set; } = -23;
+    public virtual int ButtonPositionX { get; set; } = 138;
+    public virtual int ButtonPositionY { get; set; } = -4;
 
     public virtual int ButtonFontSize { get; set; } = 3;
-    public virtual int ButtonPrefWidth { get; set; } = 13;
-    public virtual int ButtonPrefHeight { get; set; } = 7;
+    public virtual int ButtonPrefWidth { get; set; } = 11;
+    public virtual int ButtonPrefHeight { get; set; } = 6;
 
     public virtual string MessageHelp { get; set; } = "! To request a WIP, go to http://catse.net/wip or upload the .zip anywhere on discord or on google drive, copy the download link and use the command !wip (link)";
     public virtual string MessageInvalidRequest2 { get; set; } = "! Invalid request";
@@ -173,11 +173,11 @@ namespace wipbot
 
     public void MigrateConfig_0 () {
       if (Config.Instance.ConfigVersion == 0) {
-        Config.Instance.ButtonPositionX = 151;
-        Config.Instance.ButtonPositionY = -23;
+        Config.Instance.ButtonPositionX = 138;
+        Config.Instance.ButtonPositionY = -4;
         Config.Instance.ButtonFontSize = 3;
-        Config.Instance.ButtonPrefWidth = 13;
-        Config.Instance.ButtonPrefHeight = 7;
+        Config.Instance.ButtonPrefWidth = 11;
+        Config.Instance.ButtonPrefHeight = 6;
         Config.Instance.ConfigVersion = 1;
         if (!Config.Instance.FileExtensionWhitelist.Contains("vivify"))
           Config.Instance.FileExtensionWhitelist.Add("vivify");

--- a/wipbot/Plugin.cs
+++ b/wipbot/Plugin.cs
@@ -328,7 +328,7 @@ namespace wipbot
       {
         UnityMainThreadTaskScheduler.Factory.StartNew(() => { WipbotButtonController.instance.BlueButtonText = "skip"; });
         Thread.Sleep(1000);
-        webClient.Headers.Add(HttpRequestHeader.UserAgent, "Beat Saber wipbot v1.16.0");
+        webClient.Headers.Add(HttpRequestHeader.UserAgent, "Beat Saber wipbot v1.18.0");
         if (!Directory.Exists(downloadFolder))
           Directory.CreateDirectory(downloadFolder);
         webClient.DownloadProgressChanged += (sender, args) => {

--- a/wipbot/Plugin.cs
+++ b/wipbot/Plugin.cs
@@ -179,6 +179,8 @@ namespace wipbot
         Config.Instance.ButtonPrefWidth = 13;
         Config.Instance.ButtonPrefHeight = 7;
         Config.Instance.ConfigVersion = 1;
+        if (!Config.Instance.FileExtensionWhitelist.Contains("vivify"))
+          Config.Instance.FileExtensionWhitelist.Add("vivify");
       }
     }
 

--- a/wipbot/manifest.json
+++ b/wipbot/manifest.json
@@ -3,7 +3,7 @@
   "id": "wipbot",
   "name": "wipbot",
   "author": "Catse",
-  "version": "1.16.0",
+  "version": "1.18.0",
   "description": "",
   "gameVersion": "1.38.0",
   "dependsOn": {


### PR DESCRIPTION
I'm pretty sure wipbot breaks the UI sometimes because it was updating the button state from a different thread.
Not 100% sure this fixes the issue as I haven't tested it thoroughly.